### PR TITLE
FIX Case sensitivity issue with class name

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -26,7 +26,7 @@ class Application extends Console\Application
 		$commands[] = new Commands\Release\Branch();
 		$commands[] = new Commands\Release\Translate();
 		$commands[] = new Commands\Release\Test();
-		$commands[] = new Commands\Release\Changelog();
+		$commands[] = new Commands\Release\ChangeLog();
 		$commands[] = new Commands\Release\Tag();
 		$commands[] = new Commands\Release\Push();
 		$commands[] = new Commands\Release\Archive();


### PR DESCRIPTION
Class name has a lower-case 'l' which breaks PSR-4 autoloading on case-sensitive filesystems.